### PR TITLE
lv_arduino v3.0.1 support; fixes for examples widgets_pyportal and widgets_featherwing only

### DIFF
--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -213,9 +213,12 @@ static void lv_flush_callback(lv_disp_drv_t *disp, const lv_area_t *area,
 #if (LV_USE_LOG)
 // Optional LittlevGL debug print function, writes to Serial if debug is
 // enabled when calling glue begin() function.
-static void lv_debug(lv_log_level_t level, const char *file, uint32_t line,
-                     const char *dsc) {
+static void lv_debug(lv_log_level_t level,
+    const char * file, uint32_t line, const char * fn_name, const char * dsc) {
+
   Serial.print(file);
+  Serial.write(':');
+  Serial.print(fn_name);
   Serial.write('@');
   Serial.print(line);
   Serial.write("->");

--- a/examples/widgets_featherwing/widgets_featherwing.ino
+++ b/examples/widgets_featherwing/widgets_featherwing.ino
@@ -69,7 +69,7 @@ const char *buttons[]  = {       // Button matrix labels
 // This function processes events from the button matrix
 void button_event_handler(lv_obj_t *obj, lv_event_t event) {
   if(event == LV_EVENT_VALUE_CHANGED) {
-    const char *txt = lv_btnm_get_active_btn_text(obj);
+    const char *txt = lv_btnmatrix_get_active_btn_text(obj);
     if(txt) { // NULL if pressed in frame area outside buttons
       if(txt[0] == '.') {
         // Decimal button pressed. Add decimal point to "digits" string
@@ -103,22 +103,23 @@ void button_event_handler(lv_obj_t *obj, lv_event_t event) {
 void lvgl_setup(void) {
   // Because they're referenced any time an object is drawn, styles need
   // to be permanent in scope; either declared globally (outside all
-  // functions), or static. The styles used on the container and label are
-  // never modified after they're used here, so let's use static on those...
-  static lv_style_t container_style, label_style;
-
-  // Initialize styles to the "plain" defaults
-  lv_style_copy(&container_style, &lv_style_plain);
-  lv_style_copy(&label_style, &lv_style_plain);
+  // functions), dynamically on the heap (e.g., malloc), or static.
+  // The styles used on the container and label are never modified after
+  // they're used here, so let's use static on those...
+  // base styles come from the theme definitions with the LV_THEME_* defines in
+  // "lv_conf.h"
+  static lv_style_t container_style, label_style, matrix_style, button_style;
 
   // The calculator digits are held inside a LvGL container object
   // as this gives us a little more control over positioning.
   lv_obj_t *container = lv_cont_create(lv_scr_act(), NULL);
   lv_cont_set_fit(container, LV_FIT_NONE); // Don't auto fit
   lv_obj_set_size(container, tft.width(), 50); // Full width x 50 px
-  container_style.body.main_color = lv_color_hex(0xC0C0C0); // Gray
-  container_style.body.grad_color = lv_color_hex(0x909090); // gradient
-  lv_cont_set_style(container, LV_CONT_STYLE_MAIN, &container_style);
+  lv_style_init(&container_style);
+  lv_style_set_bg_color(&container_style, LV_STATE_DEFAULT, lv_color_hex(0xC0C0C0));
+  lv_style_set_bg_grad_color(&container_style, LV_STATE_DEFAULT, lv_color_hex(0x909090));
+  lv_style_set_bg_grad_dir(&container_style, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_add_style(container, LV_CONT_PART_MAIN, &container_style);
 
   // Calculator digits are just a text label inside the container,
   // refreshed whenever the global "digits" string changes.
@@ -128,13 +129,19 @@ void lvgl_setup(void) {
   lv_label_set_long_mode(digits_label, LV_LABEL_LONG_CROP);
   lv_obj_set_size(digits_label, tft.width() - 40, 30);
   lv_label_set_align(digits_label, LV_LABEL_ALIGN_RIGHT);
+  lv_style_init(&label_style);
+  lv_obj_add_style(digits_label, LV_LABEL_PART_MAIN, &label_style);
 
   // Fill the remaining space with the button matrix.
-  lv_obj_t *button_matrix = lv_btnm_create(lv_scr_act(), NULL);
-  lv_btnm_set_map(button_matrix, buttons);
+  lv_obj_t *button_matrix = lv_btnmatrix_create(lv_scr_act(), NULL);
+  lv_btnmatrix_set_map(button_matrix, buttons);
   lv_obj_align(button_matrix, NULL, LV_ALIGN_IN_TOP_LEFT, 0, 50);
   lv_obj_set_size(button_matrix, tft.width(), tft.height() - 50);
   lv_obj_set_event_cb(button_matrix, button_event_handler);
+  lv_style_init(&matrix_style);
+  lv_obj_add_style(button_matrix, LV_BTNMATRIX_PART_BG, &matrix_style);
+  lv_style_init(&button_style);
+  lv_obj_add_style(button_matrix, LV_BTNMATRIX_PART_BTN, &button_style);
 }
 
 #else // Keyboard demo


### PR DESCRIPTION
Currently, the examples fail to build against the latest master branch of lvgl/lv_arduino (3.0.1). This PR updates the glue code to support the latest debug print callback signature and also fixes the PyPortal and Featherwing widget examples by using the new LvGL style/theme API. 

The Clue and Gizmo widget examples have not been updated because I do not own one of those devices to test against.

