### PR TITLE
Debounce presses for STMPE610

### DIFF
--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -114,6 +114,7 @@ static bool touchscreen_read(struct _lv_indev_drv_t *indev_drv,
     disp->dmaWait();
     disp->endWrite();
     if ((fifo = touch->bufferSize())) { // 1 or more points await
+      release_count = 0;
       data->state = LV_INDEV_STATE_PR;  // Is PRESSED
       TS_Point p = touch->getPoint();
       // Serial.printf("%d %d %d\r\n", p.x, p.y, p.z);
@@ -151,7 +152,12 @@ static bool touchscreen_read(struct _lv_indev_drv_t *indev_drv,
       }
 #endif
     } else {                            // FIFO empty
-      data->state = LV_INDEV_STATE_REL; // Is RELEASED
+      release_count += (release_count < 255);
+      if (release_count >= 2) {
+        data->state = LV_INDEV_STATE_REL; // Is REALLY RELEASED
+      } else {
+        data->state = LV_INDEV_STATE_PR; // Is STILL PRESSED
+      }
     }
 
     data->point.x = last_x; // Last-pressed coordinates


### PR DESCRIPTION
This change addresses the fact that the STMPE610 is not fast enough to keep up with continuous presses. 
This is mostly related to the fact that we are polling the STMPE610 and the way it operates. 

The debounce is kept at 2 to minimize the lag this could generate. If this code were to get to faster MCUs it might make sense to move it to a define.

This change has been tested on a ESP32 Feather with the TFT Featherwing and lv_arduino-3.0.1 (LV_USE_USER_DATA == 1)
