### PR TITLE
Fix logging callback definition.

### DIFF
--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -207,7 +207,7 @@ static void lv_flush_callback(lv_disp_drv_t *disp, const lv_area_t *area,
 // Optional LittlevGL debug print function, writes to Serial if debug is
 // enabled when calling glue begin() function.
 static void lv_debug(lv_log_level_t level, const char *file, uint32_t line,
-                     const char *dsc) {
+                     const char * fn_name, const char *dsc) {
   Serial.print(file);
   Serial.write('@');
   Serial.print(line);

--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -207,7 +207,7 @@ static void lv_flush_callback(lv_disp_drv_t *disp, const lv_area_t *area,
 // Optional LittlevGL debug print function, writes to Serial if debug is
 // enabled when calling glue begin() function.
 static void lv_debug(lv_log_level_t level, const char *file, uint32_t line,
-                     const char * fn_name, const char *dsc) {
+                     const char *fn_name, const char *dsc) {
   Serial.print(file);
   Serial.write('@');
   Serial.print(line);


### PR DESCRIPTION
The LVGL custom log callback prototype has changed to also include a parameter for the function name.

When enabling the `LV_USE_LOG ` flag in `lv_conf.h`, Glue fails to compile due to this missing parameter in the callback definition.

