### PR TITLE
Fix initializer order warning.

### DIFF
--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -225,7 +225,7 @@ static void lv_debug(lv_log_level_t level, const char *file, uint32_t line,
  *
  */
 Adafruit_LvGL_Glue::Adafruit_LvGL_Glue(void)
-    : lv_pixel_buf(NULL), first_frame(true) {
+    : first_frame(true), lv_pixel_buf(NULL) {
 #if defined(ARDUINO_ARCH_SAMD)
   zerotimer = NULL;
 #endif


### PR DESCRIPTION
The initializer list is not in the same order as the members declared in the class, resulting in a warning (or error) during compilation.