### PR TITLE
Fix: End SPI transaction after flushing to display.

### DIFF
--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -199,7 +199,7 @@ static void lv_flush_callback(lv_disp_drv_t *disp, const lv_area_t *area,
   display->setAddrWindow(area->x1, area->y1, width, height);
   display->writePixels((uint16_t *)color_p, width * height, false,
                        LV_COLOR_16_SWAP);
-
+  display->endWrite();
   lv_disp_flush_ready(disp);
 }
 


### PR DESCRIPTION
Board: Adafruit ESP32 Feather

One-liner code fix! :-)

When loading images from an SD card, LVGL reads a few rows of the bitmap into memory before invoking the flush callback method (as defined in LVGL Glue) to draw the pixels on the screen. Once done, LVGL attempts to read more rows of data from the SD card, however a deadlock occurs and the program stops responding.

After spending many hours diagnosing the problem, I discovered that the flush callback method in LVGL Glue begins an SPI transaction by invoking `display->startWrite()` before writing the pixels on the display, however there is no corresponding `display->endWrite();` afterwards to end the SPI transaction. 

When an SPI transaction is started on the ESP32, a mutex lock is acquired (see [esp32-hal-spi.c](https://github.com/espressif/arduino-esp32/blob/master/cores/esp32/esp32-hal-spi.c#L1011)) - it looks like this needs to be released (see [spiEndTransaction()](https://github.com/espressif/arduino-esp32/blob/master/cores/esp32/esp32-hal-spi.c#L1070)) before other SPI devices can be used otherwise their requests to begin an SPI transaction will wait indefinitely for the lock to be released.

Confirmed that this fix works on an Adafruit ESP32 Feather with a 3.5" TFT Featherwing.




