### PR TITLE
Tie lib dependency to LittlevGL 7.11, fix some CI warnings & errors

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -20,7 +20,7 @@ jobs:
       run: bash ci/actions_install.sh
 
     - name: test platforms
-      run: python3 ci/build_platform.py cpx_ada cpb clue pyportal funhouse
+      run: python3 ci/build_platform.py cpx_ada cpb clue pyportal
 
     - name: clang
       run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 

--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -371,7 +371,7 @@ LvGLStatus Adafruit_LvGL_Glue::begin(Adafruit_SPITFT *tft, void *touch,
 
     // status is still ERR_ALLOC until proven otherwise...
     if ((zerotimer = new Adafruit_ZeroTimer(TIMER_NUM))) {
-      uint8_t divider = 1;
+      uint16_t divider = 1;
       uint16_t compare = 0;
       tc_clock_prescaler prescaler = TC_CLOCK_PRESCALER_DIV1;
 

--- a/Adafruit_LvGL_Glue_SD.cpp
+++ b/Adafruit_LvGL_Glue_SD.cpp
@@ -21,7 +21,7 @@ static lv_fs_res_t sd_open(struct _lv_fs_drv_t *drv, void *file_p,
   SdFat *sd = glue->sd;
   file_t file = sd->open(path);
 
-  if (file == NULL) {
+  if (!file) {
     LV_LOG_ERROR("Failed to open file %s", path);
     return LV_FS_RES_UNKNOWN;
   }

--- a/examples/hello_funhouse/hello_funhouse.ino
+++ b/examples/hello_funhouse/hello_funhouse.ino
@@ -1,4 +1,4 @@
-// Minimal "Hello" example for LittlevGL on Adafruit CLUE. Requires
+// Minimal "Hello" example for LittlevGL on Adafruit Funhouse. Requires
 // LittlevGL, Adafruit_LvGL_Glue, Adafruit_GFX and Adafruit_ST7735
 // libraries.
 
@@ -7,8 +7,6 @@
 #include <Adafruit_LvGL_Glue.h> // Always include this BEFORE lvgl.h!
 #include <lvgl.h>
 #include <Adafruit_ST7789.h>
-
-#define TFT_ROTATION   2 // Landscape orientation on FUNHOUSE
 
 Adafruit_ST7789    tft(TFT_CS, TFT_DC, TFT_RESET);
 Adafruit_LvGL_Glue glue;
@@ -28,7 +26,6 @@ void setup(void) {
 
   // Initialize display BEFORE glue setup
   tft.init(240, 240);
-  tft.setRotation(TFT_ROTATION);
   pinMode(TFT_BACKLIGHT, OUTPUT);
   digitalWrite(TFT_BACKLIGHT, HIGH);
 
@@ -46,8 +43,3 @@ void loop(void) {
   lv_task_handler(); // Call LittleVGL task handler periodically
   delay(5);
 }
-
-// NOTE TO FUTURE SELF: this sketch is essentially the same as the Gizmo
-// widgets example. If updating one sketch, make sure the other is kept
-// in sync. Aside from screen setup, differences include backlight control
-// and A/B button setup & read (CPX is active high, CLUE is active low).

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This library works in conjunction with LittlevGL (an embedded system G
 category=Display
 url=https://github.com/adafruit/Adafruit_LvGL_Glue
 architectures=samd, nrf52, esp32
-depends=Adafruit GFX Library, Adafruit TouchScreen, Adafruit STMPE610, Adafruit Zero DMA Library, Adafruit HX8357 Library, Adafruit ILI9341, Adafruit ZeroTimer Library, Adafruit ST7735 and ST7789 Library, lvgl, SdFat - Adafruit Fork
+depends=Adafruit GFX Library, Adafruit TouchScreen, Adafruit STMPE610, Adafruit Zero DMA Library, Adafruit HX8357 Library, Adafruit ILI9341, Adafruit ZeroTimer Library, Adafruit ST7735 and ST7789 Library, lvgl@7.11.0, SdFat - Adafruit Fork


### PR DESCRIPTION
Had to disable ESP32 CI for the time being…the examples can’t compile within the 60-second build timeout. Other platforms are OK.