### PR TITLE
Update library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This library works in conjunction with LittlevGL (an embedded system G
 category=Display
 url=https://github.com/adafruit/Adafruit_LvGL_Glue
 architectures=samd, nrf52, esp32
-depends=Adafruit GFX Library, Adafruit TouchScreen, Adafruit STMPE610, Adafruit Zero DMA Library, Adafruit HX8357 Library, Adafruit ILI9341, Adafruit ZeroTimer Library, Adafruit ST7735 and ST7789 Library, lvgl@8.2.0, SdFat - Adafruit Fork
+depends=Adafruit GFX Library, Adafruit TouchScreen, Adafruit STMPE610, Adafruit Zero DMA Library, Adafruit HX8357 Library, Adafruit ILI9341, Adafruit ZeroTimer Library, Adafruit ST7735 and ST7789 Library, lvgl (=8.2.0), SdFat - Adafruit Fork

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit LittlevGL Glue Library
-version=2.1.0
+version=2.1.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Simplifies use of LittlevGL library with Adafruit displays.


### PR DESCRIPTION
Change version constraint format to fix arduino registry

Linting error listed in arduino library registry [Expand version 2.1.0](https://downloads.arduino.cc/libraries/logs/github.com/adafruit/Adafruit_LvGL_Glue/) According to the "depends" section of https://arduino.github.io/arduino-cli/0.29/library-specification/#libraryproperties-file-format  More specifically https://arduino.github.io/arduino-cli/0.29/library-specification/#version-constraints

Fixes #15 