### PR TITLE
Be able to overwrite the touchscreen define values

### DIFF
--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -56,10 +56,18 @@ void TIMER_ISR(void) {
 #define TS_MAXY 3750
 
 // Same, for ADC touchscreen
-#define ADC_XMIN 325
-#define ADC_XMAX 750
-#define ADC_YMIN 240
-#define ADC_YMAX 840
+#ifndef ADC_XMIN
+  #define ADC_XMIN 325
+#endif
+#ifndef ADC_XMAX
+  #define ADC_XMAX 750
+#endif
+#ifndef ADC_YMIN
+  #define ADC_YMIN 240
+#endif
+#ifndef ADC_YMAX
+  #define ADC_YMAX 840
+#endif
 
 static void touchscreen_read(struct _lv_indev_drv_t *indev_drv,
                              lv_indev_data_t *data) {

--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -57,16 +57,16 @@ void TIMER_ISR(void) {
 
 // Same, for ADC touchscreen
 #ifndef ADC_XMIN
-  #define ADC_XMIN 325
+#define ADC_XMIN 325
 #endif
 #ifndef ADC_XMAX
-  #define ADC_XMAX 750
+#define ADC_XMAX 750
 #endif
 #ifndef ADC_YMIN
-  #define ADC_YMIN 240
+#define ADC_YMIN 240
 #endif
 #ifndef ADC_YMAX
-  #define ADC_YMAX 840
+#define ADC_YMAX 840
 #endif
 
 static void touchscreen_read(struct _lv_indev_drv_t *indev_drv,


### PR DESCRIPTION
I have an Adafruit PyPortal Titano. Using the LvGL Glue component the touch points are shifted. 
So I have executed a callibration and the values of the `ADC_*` defines in `Adafruit_LvGL_Glue.cpp` divergate to the ones  I need for my PyPortal Titano. Therefor I identified the following values:
```C
#define ADC_XMIN 200
#define ADC_XMAX 870
#define ADC_YMIN 120
#define ADC_YMAX 920
```
So that there could be other touch devices with other values in the future, it would be great to be able to overwrite those defined values from external.

Therefor I would be appreciate, if those defines could be wrapped in `ifndef` constructs.