### PR TITLE
Add TSC2007 support

### DIFF
--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -121,6 +121,7 @@ static void touchscreen_read(struct _lv_indev_drv_t *indev_drv,
   Adafruit_LvGL_Glue *glue = (Adafruit_LvGL_Glue *)indev_drv->user_data;
   Adafruit_SPITFT *disp = glue->display;
 
+#ifdef __USE_TOUCHSCREEN_H__
   if (glue->is_adc_touch) {
     TouchScreen *touch = (TouchScreen *)glue->touchscreen;
     TSPoint p = touch->getPoint();
@@ -162,19 +163,36 @@ static void touchscreen_read(struct _lv_indev_drv_t *indev_drv,
     data->point.y = last_y;
     data->continue_reading = false; // No buffering of ADC touch data
   } else {
+#else //__USE_TOUCHSCREEN_H__
+if (true) {
+#endif //__USE_TOUCHSCREEN_H__
     uint8_t fifo; // Number of points in touchscreen FIFO
     bool more = false;
+#if TSC2007_TS
+    Adafruit_TSC2007 *touch = (Adafruit_TSC2007 *)glue->touchscreen;
+#else
     Adafruit_STMPE610 *touch = (Adafruit_STMPE610 *)glue->touchscreen;
+#endif
     // Before accessing SPI touchscreen, wait on any in-progress
     // DMA screen transfer to finish (shared bus).
     disp->dmaWait();
     disp->endWrite();
+#if TSC2007_TS
+    if (! digitalRead(glue->tsc_irq_pin)) {
+      uint16_t x, y, z1, z2;
+      if (touch->read_touch(&x, &y, &z1, &z2) && (z1 > 100)) {
+        TS_Point p;
+        p.x = x;
+        p.y = y;
+        data->state = LV_INDEV_STATE_PR;  // Is PRESSED
+#else
     if ((fifo = touch->bufferSize())) { // 1 or more points await
       data->state = LV_INDEV_STATE_PR;  // Is PRESSED
       TS_Point p = touch->getPoint();
+#endif
       // Serial.printf("%d %d %d\r\n", p.x, p.y, p.z);
-      // On big TFT FeatherWing, raw X axis is flipped??
-      if ((glue->display->width() == 480) || (glue->display->height() == 480)) {
+      // On big TFT FeatherWing and V2 FeatherWings, raw X axis is flipped??
+      if ((glue->display->width() == 480) || (glue->display->height() == 480) || TSC2007_TS) {
         p.x = (TS_MINX + TS_MAXX) - p.x;
       }
       switch (glue->display->getRotation()) {
@@ -204,6 +222,9 @@ static void touchscreen_read(struct _lv_indev_drv_t *indev_drv,
       // doesn't seem to be necessary on SAMD or ESP32. ???
       if (!more) {
         delay(50);
+      }
+#endif
+#if TSC2007_TS
       }
 #endif
     } else {                            // FIFO empty
@@ -292,7 +313,7 @@ Adafruit_LvGL_Glue::~Adafruit_LvGL_Glue(void) {
   // Probably other stuff that could be deallocated here
 }
 
-// begin() function is overloaded for STMPE610 touch, ADC touch, or none.
+// begin() function is overloaded for STMPE610/TSC2007 touch, ADC touch, or none.
 
 // Pass in POINTERS to ALREADY INITIALIZED display & touch objects (user code
 // should have previously called corresponding begin() functions and checked
@@ -301,25 +322,6 @@ Adafruit_LvGL_Glue::~Adafruit_LvGL_Glue(void) {
 // touch arg can be NULL (or left off) if using LittlevGL as a passive widget
 // display.
 
-/**
- * @brief Configure the glue layer and the underlying LvGL code to use the given
- * TFT display driver instance and touchscreen controller
- *
- * @param tft Pointer to an **already initialized** display object instance
- * @param touch Pointer to an **already initialized** `Adafruit_STMPE610`
- * touchscreen controller object instance
- * @param debug Debug flag to enable debug messages. Only used if LV_USE_LOG is
- * configured in LittleLVGL's lv_conf.h
- * @return LvGLStatus The status of the initialization:
- * * LVGL_OK : Success
- * * LVGL_ERR_TIMER : Failure to set up timers
- * * LVGL_ERR_ALLOC : Failure to allocate memory
- */
-LvGLStatus Adafruit_LvGL_Glue::begin(Adafruit_SPITFT *tft,
-                                     Adafruit_STMPE610 *touch, bool debug) {
-  is_adc_touch = false;
-  return begin(tft, (void *)touch, debug);
-}
 /**
  * @brief Configure the glue layer and the underlying LvGL code to use the given
  * TFT display driver and touchscreen controller instances
@@ -334,11 +336,13 @@ LvGLStatus Adafruit_LvGL_Glue::begin(Adafruit_SPITFT *tft,
  * * LVGL_ERR_TIMER : Failure to set up timers
  * * LVGL_ERR_ALLOC : Failure to allocate memory
  */
+#ifdef __USE_TOUCHSCREEN_H__
 LvGLStatus Adafruit_LvGL_Glue::begin(Adafruit_SPITFT *tft, TouchScreen *touch,
                                      bool debug) {
   is_adc_touch = true;
   return begin(tft, (void *)touch, debug);
 }
+#endif //__USE_TOUCHSCREEN_H__
 /**
  * @brief Configure the glue layer and the underlying LvGL code to use the given
  * TFT display driver and touchscreen controller instances
@@ -355,10 +359,20 @@ LvGLStatus Adafruit_LvGL_Glue::begin(Adafruit_SPITFT *tft, bool debug) {
   return begin(tft, (void *)NULL, debug);
 }
 
-LvGLStatus Adafruit_LvGL_Glue::begin(Adafruit_SPITFT *tft, void *touch,
+#if TSC2007_TS
+LvGLStatus Adafruit_LvGL_Glue::begin(Adafruit_SPITFT *tft, Adafruit_TSC2007 *touch,
+                                     u_int16_t irq_pin,
                                      bool debug) {
-
+#else
+LvGLStatus Adafruit_LvGL_Glue::begin(Adafruit_SPITFT *tft, Adafruit_STMPE610 *touch,
+                                     bool debug) {
+#endif
+  Serial.println("A");
+  String LVGL_Arduino = "Hello Arduino! ";
+  LVGL_Arduino += String('V') + lv_version_major() + "." + lv_version_minor() + "." + lv_version_patch();
+  Serial.println(LVGL_Arduino);
   lv_init();
+  Serial.println("B");
 #if (LV_USE_LOG)
   if (debug) {
     lv_log_register_print_cb(lv_debug); // Register debug print function
@@ -375,6 +389,9 @@ LvGLStatus Adafruit_LvGL_Glue::begin(Adafruit_SPITFT *tft, void *touch,
 
     display = tft;
     touchscreen = (void *)touch;
+#if TSC2007_TS
+    tsc_irq_pin = irq_pin;
+#endif
 
     // Initialize LvGL display buffers. The "second half" buffer is only
     // used if USE_SPI_DMA is enabled in Adafruit_GFX.

--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -367,12 +367,10 @@ LvGLStatus Adafruit_LvGL_Glue::begin(Adafruit_SPITFT *tft, Adafruit_TSC2007 *tou
 LvGLStatus Adafruit_LvGL_Glue::begin(Adafruit_SPITFT *tft, Adafruit_STMPE610 *touch,
                                      bool debug) {
 #endif
-  Serial.println("A");
   String LVGL_Arduino = "Hello Arduino! ";
   LVGL_Arduino += String('V') + lv_version_major() + "." + lv_version_minor() + "." + lv_version_patch();
   Serial.println(LVGL_Arduino);
   lv_init();
-  Serial.println("B");
 #if (LV_USE_LOG)
   if (debug) {
     lv_log_register_print_cb(lv_debug); // Register debug print function

--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -367,9 +367,6 @@ LvGLStatus Adafruit_LvGL_Glue::begin(Adafruit_SPITFT *tft, Adafruit_TSC2007 *tou
 LvGLStatus Adafruit_LvGL_Glue::begin(Adafruit_SPITFT *tft, Adafruit_STMPE610 *touch,
                                      bool debug) {
 #endif
-  String LVGL_Arduino = "Hello Arduino! ";
-  LVGL_Arduino += String('V') + lv_version_major() + "." + lv_version_minor() + "." + lv_version_patch();
-  Serial.println(LVGL_Arduino);
   lv_init();
 #if (LV_USE_LOG)
   if (debug) {

--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -100,11 +100,18 @@ void TIMER_ISR(void) {
 
 // TOUCHSCREEN STUFF -------------------------------------------------------
 
-// STMPE610 calibration for raw touch data
+// STMPE610/TSC2007 calibration for raw touch data
+#ifdef TSC2007_TS
+#define TS_MINX 3800
+#define TS_MAXX 300
+#define TS_MINY 185
+#define TS_MAXY 3700
+#else
 #define TS_MINX 100
 #define TS_MAXX 3800
 #define TS_MINY 100
 #define TS_MAXY 3750
+#endif //TSC2007_TS
 
 // Same, for ADC touchscreen
 #define ADC_XMIN 325

--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -101,7 +101,7 @@ void TIMER_ISR(void) {
 // TOUCHSCREEN STUFF -------------------------------------------------------
 
 // STMPE610/TSC2007 calibration for raw touch data
-#ifdef TSC2007_TS
+#if TSC2007_TS
 #define TS_MINX 300
 #define TS_MAXX 3800
 #define TS_MINY 185

--- a/Adafruit_LvGL_Glue.cpp
+++ b/Adafruit_LvGL_Glue.cpp
@@ -102,8 +102,8 @@ void TIMER_ISR(void) {
 
 // STMPE610/TSC2007 calibration for raw touch data
 #ifdef TSC2007_TS
-#define TS_MINX 3800
-#define TS_MAXX 300
+#define TS_MINX 300
+#define TS_MAXX 3800
 #define TS_MINY 185
 #define TS_MAXY 3700
 #else

--- a/examples/hello_featherwing/hello_featherwing.ino
+++ b/examples/hello_featherwing/hello_featherwing.ino
@@ -5,14 +5,23 @@
 // so this sketch can be copied-and-pasted to serve as a starting point for
 // other projects. If display is scrambled, check that correct FeatherWing
 // type is selected below (set BIG_FEATHERWING to 0 or 1 as needed).
-
+// If the display is a V2 with the TSC2007 set FEATHER_V2 to 1.
+// If you are using an ESP32 with PSRAM then enable BOARD_HAS_PSRAM in lv_conf.h.
 // Prior Adafruit_LvGL_Glue users: see hello_changes example for updates!
 
 #define BIG_FEATHERWING 0 // Set this to 1 for 3.5" (480x320) FeatherWing!
+#ifndef FEATHER_V2
+#define FEATHER_V2 0 // Set this to 1 for V2 TSC2007 touchscreen displays
+#endif
 
 #include <Adafruit_LvGL_Glue.h> // Always include this BEFORE lvgl.h!
 #include <lvgl.h>
+#if FEATHER_V2
+#include <Adafruit_TSC2007.h>
+#include <Wire.h>
+#else
 #include <Adafruit_STMPE610.h>
+#endif
 
 #ifdef ESP32
    #define TFT_CS   15
@@ -34,17 +43,35 @@
   Adafruit_ILI9341 tft(TFT_CS, TFT_DC);
 #endif
 
+#if FEATHER_V2
+#define TSC_IRQ STMPE_CS
+Adafruit_TSC2007 ts=Adafruit_TSC2007();
+#else
 Adafruit_STMPE610  ts(STMPE_CS);
+#endif
+
 Adafruit_LvGL_Glue glue;
 
 // This example sketch's LittlevGL UI-building calls are all in this
-// function rather than in setup(), so simple programs can just 
+// function rather than in setup(), so simple programs can just
 // copy-and-paste this sketch as a starting point, then embellish here:
 void lvgl_setup(void) {
+  // Locks LVGL resource to prevent memory corrupton on ESP32
+  // When using WiFi and LVGL_Glue, this function MUST be called PRIOR to LVGL function (`lv_`) calls
+#ifdef ESP32
+  glue.lvgl_acquire();
+#endif //ESP32
+
   // Create simple label centered on screen
   lv_obj_t *label = lv_label_create(lv_scr_act());
   lv_label_set_text(label, "Hello Arduino!");
   lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
+
+  // Unlocks LVGL resource to prevent memory corrupton on ESP32
+  // NOTE: This function MUST be called AFTER lvgl_acquire
+#ifdef ESP32
+  glue.lvgl_release();
+#endif //ESP32
 }
 
 void setup(void) {
@@ -53,6 +80,17 @@ void setup(void) {
   // Initialize display and touchscreen BEFORE glue setup
   tft.begin();
   tft.setRotation(TFT_ROTATION);
+
+#if FEATHER_V2
+  if (ts.begin(0x48, &Wire)) {
+    pinMode(TSC_IRQ, INPUT);
+  } else {
+    Serial.println("Couldn't start TSC2007 touchscreen controller");
+    for(;;);
+  }
+  // Initialize glue, passing in address of display & touchscreen
+  LvGLStatus status = glue.begin(&tft, &ts, TSC_IRQ);
+#else
   if(!ts.begin()) {
     Serial.println("Couldn't start touchscreen controller");
     for(;;);
@@ -60,6 +98,8 @@ void setup(void) {
 
   // Initialize glue, passing in address of display & touchscreen
   LvGLStatus status = glue.begin(&tft, &ts);
+#endif
+
   if(status != LVGL_OK) {
     Serial.printf("Glue error %d\r\n", (int)status);
     for(;;);
@@ -69,6 +109,11 @@ void setup(void) {
 }
 
 void loop(void) {
-  lv_task_handler(); // Call LittleVGL task handler periodically
+  // On ESP32, LittleVGL's task handler (`lv_task_handler`) is a task in
+  // FreeRTOS and is pinned to the core upon successful initialization.
+  // This means that you do not need to call `lv_task_handler()` within the loop() on ESP32
+#ifndef ESP32
+  lv_task_handler();
+#endif //ESP32
   delay(5);
 }

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This library works in conjunction with LittlevGL (an embedded system G
 category=Display
 url=https://github.com/adafruit/Adafruit_LvGL_Glue
 architectures=samd, nrf52, esp32
-depends=Adafruit GFX Library, Adafruit TouchScreen, Adafruit STMPE610, Adafruit Zero DMA Library, Adafruit HX8357 Library, Adafruit ILI9341, Adafruit ZeroTimer Library, Adafruit ST7735 and ST7789 Library, lvgl (=8.2.0), SdFat - Adafruit Fork
+depends=Adafruit GFX Library, Adafruit TouchScreen, Adafruit STMPE610, Adafruit TSC2007, Adafruit Zero DMA Library, Adafruit HX8357 Library, Adafruit ILI9341, Adafruit ZeroTimer Library, Adafruit ST7735 and ST7789 Library, lvgl (=8.2.0), SdFat - Adafruit Fork

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -185,7 +185,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 
 /*1: Print the log with 'printf';
  *0: User need to register a callback with `lv_log_register_print_cb()`*/
-#define LV_LOG_PRINTF 1
+#define LV_LOG_PRINTF 0
 
 /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
 #define LV_LOG_TRACE_MEM 1

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -46,7 +46,10 @@
 
 /*1: use custom malloc/free, 0: use the built-in `lv_mem_alloc()` and
  * `lv_mem_free()`*/
+#ifndef LV_MEM_CUSTOM
 #define LV_MEM_CUSTOM 0
+//#define LV_MEM_CUSTOM 1
+#endif //LV_MEM_CUSTOM
 #if LV_MEM_CUSTOM == 0
 /*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
 #define LV_MEM_SIZE (32U * 1024U) /*[bytes]*/
@@ -55,8 +58,10 @@
  * Can be in external SRAM too.*/
 #define LV_MEM_ADR 0 /*0: unused*/
 
+//#define BOARD_HAS_PSRAM // Enable this if using an ESP32 with PSRAM
+
 // For ESP32, give a memory pool allocator and use the PSRAM instead of flash
-#ifdef ESP32
+#if defined(ESP32) && defined (BOARD_HAS_PSRAM)
 #if LV_MEM_ADR == 0
 #define LV_MEM_POOL_INCLUDE <esp32-hal-psram.h>
 #define LV_MEM_POOL_ALLOC ps_malloc
@@ -174,11 +179,13 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
  *problem LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
  *LV_LOG_LEVEL_USER        Only logs added by the user
  *LV_LOG_LEVEL_NONE        Do not log anything*/
+#ifndef LV_LOG_LEVEL
 #define LV_LOG_LEVEL LV_LOG_LEVEL_INFO
+#endif //LV_LOG_LEVEL
 
 /*1: Print the log with 'printf';
  *0: User need to register a callback with `lv_log_register_print_cb()`*/
-#define LV_LOG_PRINTF 0
+#define LV_LOG_PRINTF 1
 
 /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
 #define LV_LOG_TRACE_MEM 1


### PR DESCRIPTION
This change adds TSC2007 support to enable use of the V2 Featherwing displays that have moved over to that touchscreen controller. It also adds some more `#defines` to enable use or disabling of other support and to allow the user to not make use of PSRAM (if the use of PSRAM is enabled on an ESP32 device that does not have it there will be a very unclear crash).

I have tested this code on a Feather HUZZAH32 ESP32 with a 2.4" Featherwing V1 and a Feather ESP32 V2 with a 2.4" Featherwing V2 with different `-D` options (in the `platformio.ini` file in my test setup) and the included changes to `examples/hello_featherwing/hello_featherwing.ino`. Touch events are generated for both setups in the USB serial output.